### PR TITLE
Fix missing RuntimeIdentifier

### DIFF
--- a/ICSharpCode.TextEditor.Sample/ICSharpCode.TextEditor.Sample.csproj
+++ b/ICSharpCode.TextEditor.Sample/ICSharpCode.TextEditor.Sample.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>ICSharpCode.TextEditor.Sample</RootNamespace>
     <AssemblyName>ICSharpCode.TextEditor.Sample</AssemblyName>
     <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/Project/ICSharpCode.TextEditor.csproj
+++ b/Project/ICSharpCode.TextEditor.csproj
@@ -21,6 +21,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <FileAlignment>4096</FileAlignment>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>

--- a/Test/ICSharpCode.TextEditor.Tests.csproj
+++ b/Test/ICSharpCode.TextEditor.Tests.csproj
@@ -22,10 +22,7 @@
     <AllowUnsafeBlocks>False</AllowUnsafeBlocks>
     <CheckForOverflowUnderflow>True</CheckForOverflowUnderflow>
     <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <FileUpgradeFlags>
-    </FileUpgradeFlags>
-    <UpgradeBackupLocation>
-    </UpgradeBackupLocation>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
     <OldToolsVersion>2.0</OldToolsVersion>
     <TargetFrameworkProfile>Client</TargetFrameworkProfile>
   </PropertyGroup>


### PR DESCRIPTION
It appears MSBuild 15.8 or 15.9 requires explicit RuntimeIdentifier=win.

Part of gitextensions/gitextensions#6497