### PR TITLE
Highlighting vcxproj.filters (xml format)

### DIFF
--- a/Project/Resources/SyntaxModes.xml
+++ b/Project/Resources/SyntaxModes.xml
@@ -352,7 +352,7 @@
 
   <Mode file="XML.xshd"
         name="XML"
-        extensions=".xml;.xsl;.xslt;.xhtml;.xsd;.syn;.lang;.manifest;.config;.addin;.xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.vcproj;.vcxproj;.resx;.user;.ilproj;.booproj;.build;.xfrm;.targets;.props;.xaml;.xpt;.xft;.map;.wsdl;.disco;.ruleset;.settings;.DotSettings;.cd;.svg;.xlf;.fodp;.fods;.fodt;.arxml" />
+        extensions=".xml;.xsl;.xslt;.xhtml;.xsd;.syn;.lang;.manifest;.config;.addin;.xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.vcproj;.vcxproj;.vcxproj.filters;.resx;.user;.ilproj;.booproj;.build;.xfrm;.targets;.props;.xaml;.xpt;.xft;.map;.wsdl;.disco;.ruleset;.settings;.DotSettings;.cd;.svg;.xlf;.fodp;.fods;.fodt;.arxml" />
 
   <Mode file="Xtend.xshd"
         name="Xtend"

--- a/Project/Resources/XML.xshd
+++ b/Project/Resources/XML.xshd
@@ -10,8 +10,7 @@ hello@exr.be
 https://github.com/ei
 -->
 
-<SyntaxDefinition name="XML" extensions=".xml;.xsl;.xslt;.xhtml;.xsd;.syn;.lang;.manifest;.config;.addin;.xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.vcproj;.vcxproj;.resx;.user;.ilproj;.booproj;.build;.xfrm;.targets;.props;.xaml;.xpt;.xft;.map;.wsdl;.disco;.ruleset;.settings;.DotSettings;.cd;.svg;.xlf;.fodp;.fods;.fodt;.arxml">
-    
+<SyntaxDefinition name="XML" extensions=".xml;.xsl;.xslt;.xhtml;.xsd;.syn;.lang;.manifest;.config;.addin;.xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.vcproj;.vcxproj;.vcxproj.filters;.resx;.user;.ilproj;.booproj;.build;.xfrm;.targets;.props;.xaml;.xpt;.xft;.map;.wsdl;.disco;.ruleset;.settings;.DotSettings;.cd;.svg;.xlf;.fodp;.fods;.fodt;.arxml">
     <Environment> 
         <Default color="Black" bgcolor="#FFFFFF"/>
         <Selection color="Black" bgcolor="#C3C3FF"/>

--- a/Project/Src/Document/HighlightingStrategy/HighlightingManager.cs
+++ b/Project/Src/Document/HighlightingStrategy/HighlightingManager.cs
@@ -9,6 +9,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace ICSharpCode.TextEditor.Document
 {
@@ -132,10 +133,8 @@ namespace ICSharpCode.TextEditor.Document
 
         public IHighlightingStrategy FindHighlighterForFile(string fileName)
         {
-            var extension = Path.GetExtension(fileName).ToUpperInvariant();
-            if (extensionsToName.TryGetValue(extension, out var highlighterName))
-                return FindHighlighter(highlighterName);
-            return DefaultHighlighting;
+            var highlighterName = extensionsToName.FirstOrDefault(e => fileName.EndsWith(e.Key, StringComparison.OrdinalIgnoreCase));
+            return highlighterName.Key == null ? DefaultHighlighting : FindHighlighter(highlighterName.Value);
         }
 
         protected virtual void OnReloadSyntaxHighlighting(EventArgs e)

--- a/Test/HighlightingManagerTests.cs
+++ b/Test/HighlightingManagerTests.cs
@@ -1,0 +1,27 @@
+﻿using ICSharpCode.TextEditor.Document;
+using NUnit.Framework;
+
+namespace ICSharpCode.TextEditor.Tests
+{
+    [TestFixture]
+    public class HighlightingManagerTests
+    {
+        [TestCase("test.xml", "XML")]
+        [TestCase("test.vcxproj.filters", "XML")] //Extension with a '.' inside
+        [TestCase("test.cs", "C#")] //lowercase
+        [TestCase("test.CS", "C#")] //Upper case
+        [TestCase("test.htm", "HTML")]
+        public void FindHighlighterForFile_Should_find_Highlight_strategy(string filename, string expectedStrategy)
+        {
+            IHighlightingStrategy highlightingStrategy = HighlightingManager.Manager.FindHighlighterForFile(filename);
+            Assert.AreEqual(expectedStrategy, highlightingStrategy.Name);
+        }
+
+        [Test]
+        public void FindHighlighterForFile_Should_not_find_Highlight_strategy()
+        {
+            IHighlightingStrategy highlightingStrategy = HighlightingManager.Manager.FindHighlighterForFile("test.unkown");
+            Assert.AreEqual("Default", highlightingStrategy.Name);
+        }
+    }
+}

--- a/Test/ICSharpCode.TextEditor.Tests.csproj
+++ b/Test/ICSharpCode.TextEditor.Tests.csproj
@@ -36,6 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="HighlightingManagerTests.cs" />
     <Compile Include="DocumentTests.cs" />
     <Compile Include="BlockCommentTests.cs" />
     <Compile Include="FoldingManagerTests.cs" />


### PR DESCRIPTION
& adapt how to find Highlighter by extension to support extensions with a '.' inside.

Fixes https://github.com/gitextensions/gitextensions/issues/6471