### PR TITLE
Syntax support for .groovy, .gradle

### DIFF
--- a/Project/ICSharpCode.TextEditor.csproj
+++ b/Project/ICSharpCode.TextEditor.csproj
@@ -232,7 +232,7 @@
     <EmbeddedResource Include="Resources\Fantom.xshd" />
     <EmbeddedResource Include="Resources\Fortran95.xshd" />
     <EmbeddedResource Include="Resources\Go.xshd" />
-    <EmbeddedResource Include="Resources\Goovy.xshd" />
+    <EmbeddedResource Include="Resources\Groovy.xshd" />
     <EmbeddedResource Include="Resources\Gui4Cli.xshd" />
     <EmbeddedResource Include="Resources\Haskell.xshd" />
     <EmbeddedResource Include="Resources\Haxe.xshd" />

--- a/Project/Resources/Groovy.xshd
+++ b/Project/Resources/Groovy.xshd
@@ -10,7 +10,7 @@ hello@exr.be
 https://github.com/ei
 -->
 
-<SyntaxDefinition name="Groovy" extensions=".groovy">
+<SyntaxDefinition name="Groovy" extensions=".groovy;.gradle">
 
     <Environment> 
         <Default color="Black" bgcolor="#FFFFFF"/>

--- a/Project/Resources/SyntaxModes.xml
+++ b/Project/Resources/SyntaxModes.xml
@@ -120,7 +120,7 @@
 
   <Mode file="Groovy.xshd"
         name="Groovy"
-        extensions=".groovy" />
+        extensions=".groovy;.gradle" />
 
   <Mode file="Gui4Cli.xshd"
         name="Gui4Cli"


### PR DESCRIPTION
.groovy existed before but file wasincorrectly named
.gradle is a DSL based on Groovy and has the same basic syntax. Standard closures could be added, but will not include those that are extended anyway.
Note that Gradle written in Kotlin has suffix .gradle.kts and is already supported (as .kts is listed).