### PR TITLE
Prevent an ArgumentOutOfRangeException

### DIFF
--- a/Project/Src/Gui/TextArea.cs
+++ b/Project/Src/Gui/TextArea.cs
@@ -131,10 +131,11 @@ namespace ICSharpCode.TextEditor
             set
             {
                 var newVirtualTop = new Point(value.X, Math.Min(MaxVScrollValue, Math.Max(val1: 0, value.Y)));
-                if (virtualTop != newVirtualTop)
+                var scrollBar = MotherTextAreaControl.VScrollBar;
+                if (virtualTop != newVirtualTop && newVirtualTop.Y >= scrollBar.Minimum && newVirtualTop.Y <= scrollBar.Maximum )
                 {
                     virtualTop = newVirtualTop;
-                    MotherTextAreaControl.VScrollBar.Value = virtualTop.Y;
+                    scrollBar.Value = virtualTop.Y;
                     Invalidate();
                 }
 


### PR DESCRIPTION
by checking the value to see if it fits between the `Minimum` and the `Maximum`
before trying to set it

Fixes https://github.com/gitextensions/gitextensions/issues/7836

I can't reproduce it but it seems that I got it when I click unintentionally
 on a commit in the revision grid when the grid was loading.