### PR TITLE
Render tabs in the text viewer

### DIFF
--- a/Project/Src/Gui/TextView.cs
+++ b/Project/Src/Gui/TextView.cs
@@ -633,7 +633,7 @@ namespace ICSharpCode.TextEditor
         // Important: Some flags combinations work on WinXP, but not on Win2000.
         // Make sure to test changes here on all operating systems.
         private const TextFormatFlags textFormatFlags =
-            TextFormatFlags.NoPadding | TextFormatFlags.NoPrefix | TextFormatFlags.PreserveGraphicsClipping;
+            TextFormatFlags.NoPadding | TextFormatFlags.NoPrefix | TextFormatFlags.PreserveGraphicsClipping | TextFormatFlags.ExpandTabs;
 
         #endregion
 


### PR DESCRIPTION
Fix #22 

This one line change seems to work for me, but I am not sure of all the ramifications of this change (feel free to offer other suggestions).  In addition, this was only tested on Windows 10 (no access to other OS's), yet the comment above the code fix says some of the flags might not work together depending on the operating system.