### PR TITLE
Fix Git Extensions #8211: Incorrect EOL in diff

### DIFF
--- a/Project/Src/Document/LineManager/EolMarker.cs
+++ b/Project/Src/Document/LineManager/EolMarker.cs
@@ -1,0 +1,10 @@
+﻿namespace ICSharpCode.TextEditor.Document
+{
+    public enum EolMarker
+    {
+        None,
+        Cr, // "\r"
+        CrLf, // "\r\n"
+        Lf // "\n"
+    }
+}

--- a/Project/Src/Document/LineManager/LineSegment.cs
+++ b/Project/Src/Document/LineManager/LineSegment.cs
@@ -17,6 +17,8 @@ namespace ICSharpCode.TextEditor.Document
     {
         internal LineSegmentTree.Enumerator treeEntry;
 
+        public EolMarker EolMarker { get; set; }
+
         public bool IsDeleted => !treeEntry.IsValid;
 
         public int LineNumber => treeEntry.CurrentIndex;

--- a/Project/Src/Gui/TextView.cs
+++ b/Project/Src/Gui/TextView.cs
@@ -200,7 +200,7 @@ namespace ICSharpCode.TextEditor
                 if (TextEditorProperties.ShowEOLMarker)
                 {
                     var eolMarkerColor = textArea.Document.HighlightingStrategy.GetColorFor("EOLMarkers");
-                    physicalXPos += DrawEOLMarker(g, eolMarkerColor.Color, selectionBeyondEOL ? bgColorBrush : backgroundBrush, physicalXPos, lineRectangle.Y);
+                    physicalXPos += DrawEOLMarker(g, eolMarkerColor.Color, selectionBeyondEOL ? bgColorBrush : backgroundBrush, physicalXPos, lineRectangle.Y, currentLine.EolMarker);
                 }
                 else
                 {
@@ -1062,17 +1062,41 @@ namespace ICSharpCode.TextEditor
             DrawString(g, "\u00BB", tabMarkerColor.GetFont(TextEditorProperties.FontContainer), color, x, y);
         }
 
-        private int DrawEOLMarker(Graphics g, Color color, Brush backBrush, int x, int y)
+        private int DrawEOLMarker(Graphics g, Color color, Brush backBrush, int x, int y, EolMarker eolMarker)
         {
             var eolMarkerColor = textArea.Document.HighlightingStrategy.GetColorFor("EOLMarkers");
 
-            var width = GetWidth(ch: '\u00B6', eolMarkerColor.GetFont(TextEditorProperties.FontContainer));
+            int eolMarkerWidth = 0;
+            string representation = "";
+
+            int backslashWidth = GetWidth(ch: '\\', eolMarkerColor.GetFont(TextEditorProperties.FontContainer));
+            int nWidth = GetWidth(ch: 'n', eolMarkerColor.GetFont(TextEditorProperties.FontContainer));
+            int rWidth = GetWidth(ch: 'r', eolMarkerColor.GetFont(TextEditorProperties.FontContainer));
+            switch (eolMarker)
+            {
+                case EolMarker.Cr:
+                    eolMarkerWidth = backslashWidth + rWidth;
+                    representation = "\\r";
+                    break;
+                case EolMarker.CrLf:
+                    eolMarkerWidth = backslashWidth + rWidth + backslashWidth + nWidth;
+                    representation = "\\r\\n";
+                    break;
+                case EolMarker.Lf:
+                    eolMarkerWidth = backslashWidth + nWidth;
+                    representation = "\\n";
+                    break;
+                case EolMarker.None:
+                default:
+                    return 0;
+            }
+
             g.FillRectangle(
                 backBrush,
-                new RectangleF(x, y, width, FontHeight));
+                new RectangleF(x, y, eolMarkerWidth, FontHeight));
 
-            DrawString(g, "\u00B6", eolMarkerColor.GetFont(TextEditorProperties.FontContainer), color, x, y);
-            return width;
+            DrawString(g, representation, eolMarkerColor.GetFont(TextEditorProperties.FontContainer), color, x, y);
+            return eolMarkerWidth;
         }
 
         private void DrawVerticalRuler(Graphics g, Rectangle lineRectangle)


### PR DESCRIPTION
Fixes https://github.com/gitextensions/gitextensions/issues/8211: Incorrect EOL in diff

- allow the text editor to differentiate between various types of end-of-lines when displaying the EOL marker
- see [the Git Extensions integration PR](https://github.com/gitextensions/gitextensions/pull/9620) for screenshots of a before and after