### PR TITLE
Handle WM_MOUSEHWHEEL for horizontal touchpad scrolling

### DIFF
--- a/ICSharpCode.TextEditor.Sample/ICSharpCode.TextEditor.Sample.csproj
+++ b/ICSharpCode.TextEditor.Sample/ICSharpCode.TextEditor.Sample.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Library</OutputType>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Project/Src/Util/Win32Util.cs
+++ b/Project/Src/Util/Win32Util.cs
@@ -7,5 +7,23 @@ namespace ICSharpCode.TextEditor.Util
     {
         public static Point ToPoint(this IntPtr lparam) =>
             new Point(unchecked((int)lparam.ToInt64()));
+
+        public static int SignedLOWORD(nint n)
+            => SignedLOWORD(unchecked((int)n));
+
+        public static int SignedHIWORD(nint n)
+            => SignedHIWORD(unchecked((int)n));
+
+        public static int SignedHIWORD(int n)
+            => (int)(short)HIWORD(n);
+
+        public static int HIWORD(int n)
+            => (n >> 16) & 0xffff;
+
+        public static int LOWORD(int n)
+            => n & 0xffff;
+
+        public static int SignedLOWORD(int n)
+            => (int)(short)LOWORD(n);
     }
 }

--- a/Test/ICSharpCode.TextEditor.Tests.csproj
+++ b/Test/ICSharpCode.TextEditor.Tests.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Library</OutputType>
     <OutputPath>..\..\..\..\bin\UnitTests</OutputPath>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 4.0.2.{build}
+version: 4.1.0.{build}
 
 branches:
   except:
@@ -8,7 +8,15 @@ matrix:
   fast_finish: true
 
 # https://www.appveyor.com/docs/build-environment/#build-worker-images
-image: Visual Studio 2019
+image: Visual Studio 2022
+
+environment:
+  # Disable the .NET logo in the console output.
+  DOTNET_NOLOGO: true
+  # Disable the .NET first time experience to skip caching NuGet packages and speed up the build.
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+  # Use latest version of current used .NET version.  6.0 could use the latest of 6.0.  See .\Scripts\Update-DotnetVersion.ps1
+  GE_USE_LATEST_DOTNET: false
 
 # Build settings, not to be confused with "before_build" and "after_build".
 # "project" is relative to the original build directory and not influenced by directory changes in "before_build".


### PR DESCRIPTION
It turns out that `Panel` on which this editor is based only handles `WM_MOUSEWHEEL` which gives vertical scrolling but doesn't handle `WM_MOUSEHWHEEL` which is fired during horizontal scroll.
So I basically copy/pasted [this code](https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Control.cs,13550) used for vertical scrolling and hooked it up to vertical scroll events. Methods in `Win32Util` also came from there.

## Testing methodology
Manual testing with laptop-touchpad

## Before
https://user-images.githubusercontent.com/483659/196259300-682a9691-6371-4fb7-b649-430647e09245.mp4

## After
https://user-images.githubusercontent.com/483659/196259655-b21917cc-d3dd-424e-9a42-d1be80969565.mp4

p.s. I've also created a simple `Form` with a `Panel` and some oversized content in both x and y axises and confirmed that horizontal scrolling with touch-pad doesn't work
![image](https://user-images.githubusercontent.com/483659/196261895-56861df2-1202-4d12-b727-96a63fb2c15b.png)
