### PR TITLE
EOL markers as glyph or text

### DIFF
--- a/Project/Src/Document/DefaultTextEditorProperties.cs
+++ b/Project/Src/Document/DefaultTextEditorProperties.cs
@@ -48,7 +48,7 @@ namespace ICSharpCode.TextEditor.Document
 
         public bool ShowTabs { get; set; } = false;
 
-        public bool ShowEOLMarker { get; set; } = false;
+        public EolMarkerStyle EolMarkerStyle { get; set; } = EolMarkerStyle.None;
 
         public bool ShowInvalidLines { get; set; } = false;
 

--- a/Project/Src/Document/EolMarkerStyle.cs
+++ b/Project/Src/Document/EolMarkerStyle.cs
@@ -1,0 +1,16 @@
+// <file>
+//     <copyright see="prj:///doc/copyright.txt"/>
+//     <license see="prj:///doc/license.txt"/>
+//     <owner name="none" email=""/>
+//     <version>$Revision$</version>
+// </file>
+
+namespace ICSharpCode.TextEditor.Document
+{
+    public enum EolMarkerStyle
+    {
+        None,
+        Glyph,
+        Text
+    }
+}

--- a/Project/Src/Document/ITextEditorProperties.cs
+++ b/Project/Src/Document/ITextEditorProperties.cs
@@ -95,7 +95,7 @@ namespace ICSharpCode.TextEditor.Document
             set;
         }
 
-        bool ShowEOLMarker
+        EolMarkerStyle EolMarkerStyle
         {
             // is wrapped in text editor control
             get;

--- a/Project/Src/Gui/TextEditorControlBase.cs
+++ b/Project/Src/Gui/TextEditorControlBase.cs
@@ -493,17 +493,17 @@ namespace ICSharpCode.TextEditor
         }
 
         /// <value>
-        ///     If true EOL markers are shown in the textarea
+        ///     Whether and how EOL markers are shown in the textarea
         /// </value>
         [Category("Appearance")]
-        [DefaultValue(value: false)]
-        [Description("If true EOL markers are shown in the textarea")]
-        public bool ShowEOLMarkers
+        [DefaultValue(value: EolMarkerStyle.None)]
+        [Description("Whether and how EOL markers are shown in the textarea")]
+        public EolMarkerStyle EolMarkerStyle
         {
-            get => document.TextEditorProperties.ShowEOLMarker;
+            get => document.TextEditorProperties.EolMarkerStyle;
             set
             {
-                document.TextEditorProperties.ShowEOLMarker = value;
+                document.TextEditorProperties.EolMarkerStyle = value;
                 OptionsChanged();
             }
         }


### PR DESCRIPTION
- Turn option `bool ShowEOLMarker` into `enum EolMarkerStyle EolMarkerStyle`
- Call `textArea.Document.HighlightingStrategy.GetColorFor("EOLMarkers")` and `.GetFont()` once (only in `DrawEOLMarker`)