### PR TITLE
Disable Italics _ in markdown

### DIFF
--- a/Project/Resources/Markdown.xshd
+++ b/Project/Resources/Markdown.xshd
@@ -79,10 +79,11 @@
                 <End>__</End>
             </Span>
 
-            <Span name="Italic1" color="Black" italic="true" stopateol="true">
+            <!-- Disabled because underscore in texts is interpreted as italics -->
+            <!-- <Span name="Italic1" color="Black" italic="true" stopateol="true">
                 <Begin>_</Begin>
                 <End>_</End>
-            </Span>
+            </Span> -->
 
             <!-- Disabled because conflicts with unordered list items -->
             <!-- <Span name="Italic2" color="Black" italic="true" stopateol="true">


### PR DESCRIPTION
Closes #35 (though doesn't fix).

The styling is quite limited, so current style is treating any _ as start of italics.
' _' to '_ ' would be slightly safer, but still fail.

Italics with '*' is already disabled.