### PR TITLE
feat: Cleanup Highlighting colors

### DIFF
--- a/Project/Resources/ANTLR.xshd
+++ b/Project/Resources/ANTLR.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="ANTLR" extensions=".g;.g3;.g4">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/ActionScript.xshd
+++ b/Project/Resources/ActionScript.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="ActionScript" extensions=".as;.mx">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Ada.xshd
+++ b/Project/Resources/Ada.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Ada" extensions=".ada;.ads;.adb">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/Assembly.xshd
+++ b/Project/Resources/Assembly.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Assembly" extensions=".asm;.ASM">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value=";"/>

--- a/Project/Resources/AutoHotkey.xshd
+++ b/Project/Resources/AutoHotkey.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="AutoHotkey" extensions=".ahk">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value=";"/>

--- a/Project/Resources/Batch.xshd
+++ b/Project/Resources/Batch.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Batch" extensions="*.bat;*.cmd">
 
-    <Environment>
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
   
       <Properties>
         <Property name="LineComment" value="REM "/>

--- a/Project/Resources/Boo.xshd
+++ b/Project/Resources/Boo.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Boo" extensions=".boo">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/C#.xshd
+++ b/Project/Resources/C#.xshd
@@ -14,22 +14,7 @@ For syntax help, see Mode.xsd file
 
 <SyntaxDefinition name="C#" extensions=".cs">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/C++.xshd
+++ b/Project/Resources/C++.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="C++" extensions=".c;.h;.cc;.C;.cpp;.cxx;.hpp">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/C.xshd
+++ b/Project/Resources/C.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="C" extensions=".c">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/CSS.xshd
+++ b/Project/Resources/CSS.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="CSS" extensions=".css">
   
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
   
     <Properties>
         <Property name="BlockCommentBegin" value="/*"/>

--- a/Project/Resources/Ceylon.xshd
+++ b/Project/Resources/Ceylon.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Ceylon" extensions=".ceylon">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/ChucK.xshd
+++ b/Project/Resources/ChucK.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="ChucK" extensions=".ck">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Clojure.xshd
+++ b/Project/Resources/Clojure.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Clojure" extensions=".clj;.cljs">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value=";"/>

--- a/Project/Resources/Cocoa.xshd
+++ b/Project/Resources/Cocoa.xshd
@@ -5,22 +5,7 @@
 
 <SyntaxDefinition name="Cocoa" extensions=".atg">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/CoffeeScript.xshd
+++ b/Project/Resources/CoffeeScript.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="CoffeeScript" extensions=".coffee;.litcoffee">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Cool.xshd
+++ b/Project/Resources/Cool.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Cool" extensions=".cl">
 
-    <Environment>
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/D.xshd
+++ b/Project/Resources/D.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="D" extensions=".d">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Dart.xshd
+++ b/Project/Resources/Dart.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Dart" extensions=".dart">
 
-    <Environment>
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Delphi.xshd
+++ b/Project/Resources/Delphi.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Delphi" extensions=".dpr">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Eiffel.xshd
+++ b/Project/Resources/Eiffel.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Eiffel" extensions=".e">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/Elixir.xshd
+++ b/Project/Resources/Elixir.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Elixir" extensions=".ex;.exs">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Erlang.xshd
+++ b/Project/Resources/Erlang.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Erlang" extensions=".erl;.hrl">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="%"/>

--- a/Project/Resources/F#.xshd
+++ b/Project/Resources/F#.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="F#" extensions=".fs;.fsi;.fsx;.fsscript">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Falcon.xshd
+++ b/Project/Resources/Falcon.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Falcon" extensions=".fal">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Fantom.xshd
+++ b/Project/Resources/Fantom.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Fantom" extensions=".fan">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Fortran95.xshd
+++ b/Project/Resources/Fortran95.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Fortran 95" extensions=".f90;.f95;.f03">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="!"/>

--- a/Project/Resources/GherkinFeature.xshd
+++ b/Project/Resources/GherkinFeature.xshd
@@ -1,22 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- https://reqnroll.net/ , Specflow, ...-->
 <SyntaxDefinition name="GherkinFeature" extensions=".feature">
-    <Environment>
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Go.xshd
+++ b/Project/Resources/Go.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Go" extensions=".go">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Groovy.xshd
+++ b/Project/Resources/Groovy.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Groovy" extensions=".groovy;.gradle">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Gui4Cli.xshd
+++ b/Project/Resources/Gui4Cli.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Gui4Cli" extensions=".gui;.gc">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/HTML.xshd
+++ b/Project/Resources/HTML.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="HTML" extensions=".html;.htm;.xhtml;.shtml;.shtm;.xht;.hta">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="BlockCommentBegin" value="&lt;!--"/>

--- a/Project/Resources/Haskell.xshd
+++ b/Project/Resources/Haskell.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Haskell" extensions=".hs;.lhs">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/Haxe.xshd
+++ b/Project/Resources/Haxe.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Haxe" extensions=".hx">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#E0E0E5"/>
-        <SpaceMarkers color="#E0E0E5"/>
-        <TabMarkers color="#E0E0E5"/>
-        <InvalidLines color="#E0E0E5"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/ILYC.xshd
+++ b/Project/Resources/ILYC.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="ILYC" extensions=".ilc">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/INI.xshd
+++ b/Project/Resources/INI.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="INI" extensions=".ini;.inf;.wer;.dof;.editorconfig">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value=";"/>

--- a/Project/Resources/Icon.xshd
+++ b/Project/Resources/Icon.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Icon" extensions=".icn">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Io.xshd
+++ b/Project/Resources/Io.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Io" extensions=".io">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/JSON.xshd
+++ b/Project/Resources/JSON.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="JSON" extensions=".json">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Java.xshd
+++ b/Project/Resources/Java.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Java" extensions=".java">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/JavaScript.xshd
+++ b/Project/Resources/JavaScript.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="JavaScript" extensions=".js;.jsx">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Julia.xshd
+++ b/Project/Resources/Julia.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Julia" extensions=".jl">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Just BASIC.xshd
+++ b/Project/Resources/Just BASIC.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Just BASIC" extensions=".bas">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="'"/>

--- a/Project/Resources/KiXtart.xshd
+++ b/Project/Resources/KiXtart.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="KiXtart" extensions=".kix">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="LineComment" value=";"/>

--- a/Project/Resources/Kotlin.xshd
+++ b/Project/Resources/Kotlin.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Kotlin" extensions=".kt;.kts">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Lean.xshd
+++ b/Project/Resources/Lean.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Lean" extensions=".lean;.hlean">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/Lisp.xshd
+++ b/Project/Resources/Lisp.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Lisp" extensions=".lisp;.lsp">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value=";"/>

--- a/Project/Resources/Lua.xshd
+++ b/Project/Resources/Lua.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Lua" extensions=".lua">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/Markdown.xshd
+++ b/Project/Resources/Markdown.xshd
@@ -1,21 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <SyntaxDefinition name="Markdown" extensions=".md">
-    <Environment>
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <RuleSets>
 

--- a/Project/Resources/Nemerle.xshd
+++ b/Project/Resources/Nemerle.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Nemerle" extensions=".n">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Nim.xshd
+++ b/Project/Resources/Nim.xshd
@@ -13,22 +13,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Nim" extensions=".nim">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/OCaml.xshd
+++ b/Project/Resources/OCaml.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="OCaml" extensions=".ml;.mli">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="BlockCommentBegin" value="(*"/>

--- a/Project/Resources/Objective-C.xshd
+++ b/Project/Resources/Objective-C.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Objective-C" extensions=".m">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/PHP.xshd
+++ b/Project/Resources/PHP.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="PHP" extensions=".php;.php3;.php4;.php5;.hh">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/ParaSail.xshd
+++ b/Project/Resources/ParaSail.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="ParaSail" extensions=".psi;.psl">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Pascal.xshd
+++ b/Project/Resources/Pascal.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Pascal" extensions=".pas">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Pike.xshd
+++ b/Project/Resources/Pike.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Pike" extensions=".pike">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/PowerShell.xshd
+++ b/Project/Resources/PowerShell.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="PowerShell" extensions=".ps1;.psm1">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Prolog.xshd
+++ b/Project/Resources/Prolog.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Prolog" extensions=".pl;.pro">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="%"/>

--- a/Project/Resources/PureScript.xshd
+++ b/Project/Resources/PureScript.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="PureScript" extensions=".purs">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/Python.xshd
+++ b/Project/Resources/Python.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Python" extensions=".py">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
             
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/R.xshd
+++ b/Project/Resources/R.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="R" extensions=".r">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Registry.xshd
+++ b/Project/Resources/Registry.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Registry" extensions=".reg">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value=";"/>

--- a/Project/Resources/Resource.xshd
+++ b/Project/Resources/Resource.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Resource" extensions=".rc">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#EAEAEA"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Rexx.xshd
+++ b/Project/Resources/Rexx.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Rexx" extensions=".rex">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="BlockCommentBegin" value="/*"/>

--- a/Project/Resources/Rust.xshd
+++ b/Project/Resources/Rust.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Rust" extensions=".rs">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/SQF.xshd
+++ b/Project/Resources/SQF.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="SQF" extensions=".sqf;.sqs">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/SQL.xshd
+++ b/Project/Resources/SQL.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="SQL" extensions=".sql">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/Scala.xshd
+++ b/Project/Resources/Scala.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Scala" extensions=".scala">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Scheme.xshd
+++ b/Project/Resources/Scheme.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Scheme" extensions=".scm;.ss">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value=";"/>

--- a/Project/Resources/Solidity.xshd
+++ b/Project/Resources/Solidity.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Solidity" extensions=".sol">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
 
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Spike.xshd
+++ b/Project/Resources/Spike.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Spike" extensions=".spk">
 
-    <Environment>
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Swift.xshd
+++ b/Project/Resources/Swift.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Swift" extensions=".swift">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/TCL.xshd
+++ b/Project/Resources/TCL.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="TCL" extensions=".tcl">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Thrift.xshd
+++ b/Project/Resources/Thrift.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Thrift" extensions=".thrift">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/TypeScript.xshd
+++ b/Project/Resources/TypeScript.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="TypeScript" extensions=".ts;.tsx">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/VB.NET.xshd
+++ b/Project/Resources/VB.NET.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="VB.NET" extensions=".vb">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="'"/>

--- a/Project/Resources/VBScript.xshd
+++ b/Project/Resources/VBScript.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="VBScript" extensions=".vbs">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="'"/>

--- a/Project/Resources/VHDL.xshd
+++ b/Project/Resources/VHDL.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="VHDL" extensions=".vhd;.vhdl">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="--"/>

--- a/Project/Resources/VS Solution.xshd
+++ b/Project/Resources/VS Solution.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="VS Solution" extensions=".sln">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="#"/>

--- a/Project/Resources/Vala.xshd
+++ b/Project/Resources/Vala.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Vala" extensions=".vala">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Verilog.xshd
+++ b/Project/Resources/Verilog.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Verilog" extensions=".v;.vh">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/Volt.xshd
+++ b/Project/Resources/Volt.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Volt" extensions=".volt">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/X10.xshd
+++ b/Project/Resources/X10.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="X10" extensions=".x10">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/XC.xshd
+++ b/Project/Resources/XC.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="XC" extensions=".xc">
 
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
         
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Resources/XML.xshd
+++ b/Project/Resources/XML.xshd
@@ -11,22 +11,7 @@ https://github.com/ei
 -->
 
 <SyntaxDefinition name="XML" extensions=".xml;.xsl;.xslt;.xhtml;.xsd;.syn;.lang;.manifest;.config;.addin;.xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.vcproj;.vcxproj;.vcxproj.filters;.resx;.user;.ilproj;.booproj;.build;.xfrm;.targets;.props;.xaml;.xpt;.xft;.map;.wsdl;.disco;.ruleset;.settings;.DotSettings;.cd;.svg;.xlf;.fodp;.fods;.fodt;.arxml">
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="BlockCommentBegin" value="&lt;!--"/>

--- a/Project/Resources/Xtend.xshd
+++ b/Project/Resources/Xtend.xshd
@@ -12,22 +12,7 @@ https://github.com/ei
 
 <SyntaxDefinition name="Xtend" extensions=".xtend">
     
-    <Environment> 
-        <Default color="Black" bgcolor="#FFFFFF"/>
-        <Selection color="Black" bgcolor="#C3C3FF"/>
-        <LineNumbers color="Gray" bgcolor="#FFFFFF"/>
-        <CaretMarker color="#F0F0F1"/>
-        <VRuler color="#E0E0E5"/>
-        
-        <FoldLine color="#A0A0A0" bgcolor="#FFFFFF"/>
-        <FoldMarker color="Black" bgcolor="#FFFFFF"/>
-        <SelectedFoldLine color="Black" bgcolor="#FFFFFF"/>
-        
-        <EOLMarkers color="#CACAD2"/>
-        <SpaceMarkers color="#B6B6C0"/>
-        <TabMarkers color="#B6B6C0"/>
-        <InvalidLines color="#B6B6C0"/>
-    </Environment>
+    <Environment/>
     
     <Properties>
         <Property name="LineComment" value="//"/>

--- a/Project/Src/Document/HighlightingStrategy/DefaultHighlightingStrategy.cs
+++ b/Project/Src/Document/HighlightingStrategy/DefaultHighlightingStrategy.cs
@@ -49,20 +49,19 @@ namespace ICSharpCode.TextEditor.Document
             environmentColors = new Dictionary<string, HighlightColor>
             {
                 ["Default"] = new HighlightBackground(nameof(SystemColors.WindowText), nameof(SystemColors.Window), bold: false, italic: false),
-                ["Selection"] = new HighlightColor(nameof(SystemColors.HighlightText), nameof(SystemColors.Highlight), bold: false, italic: false),
+                ["Selection"] = new HighlightColor(SystemColors.HighlightText, Color.FromArgb(0xc3, 0xc3, 0xff), bold: false, italic: false),
                 ["VRuler"] = new HighlightColor(nameof(SystemColors.ControlLight), nameof(SystemColors.Window), bold: false, italic: false),
-                ["InvalidLines"] = new HighlightColor(Color.Red, bold: false, italic: false),
-                ["CaretMarker"] = new HighlightColor(Color.Yellow, bold: false, italic: false),
+                ["InvalidLines"] = new HighlightColor(Color.FromArgb(0xB6, 0xB6, 0xC0), bold: false, italic: false),
+                ["CaretMarker"] = new HighlightColor(nameof(SystemColors.MenuBar), bold: false, italic: false),
                 ["CaretLine"] = new HighlightBackground(nameof(SystemColors.ControlLight), nameof(SystemColors.Window), bold: false, italic: false),
                 ["LineNumbers"] = new HighlightBackground(nameof(SystemColors.GrayText), nameof(SystemColors.Window), bold: false, italic: false),
                 ["FoldLine"] = new HighlightColor(nameof(SystemColors.ControlDark), bold: false, italic: false),
                 ["FoldMarker"] = new HighlightColor(nameof(SystemColors.WindowText), nameof(SystemColors.Window), bold: false, italic: false),
                 ["SelectedFoldLine"] = new HighlightColor(nameof(SystemColors.WindowText), bold: false, italic: false),
-                ["EOLMarkers"] = new HighlightColor(nameof(SystemColors.ControlLight), nameof(SystemColors.Window), bold: false, italic: false),
-                ["SpaceMarkers"] = new HighlightColor(nameof(SystemColors.ControlLight), nameof(SystemColors.Window), bold: false, italic: false),
-                ["TabMarkers"] = new HighlightColor(nameof(SystemColors.ControlLight), nameof(SystemColors.Window), bold: false, italic: false)
+                ["EOLMarkers"] = new HighlightColor(Color.FromArgb(0xca, 0xca, 0xd2), bold: false, italic: false),
+                ["SpaceMarkers"] = new HighlightColor(Color.FromArgb(0xB6, 0xB6, 0xC0), bold: false, italic: false),
+                ["TabMarkers"] = new HighlightColor(Color.FromArgb(0xB6, 0xB6, 0xC0), bold: false, italic: false)
             };
-
         }
 
         public HighlightColor DigitColor { get; set; }

--- a/Project/Src/Document/HighlightingStrategy/DefaultHighlightingStrategy.cs
+++ b/Project/Src/Document/HighlightingStrategy/DefaultHighlightingStrategy.cs
@@ -49,7 +49,7 @@ namespace ICSharpCode.TextEditor.Document
             environmentColors = new Dictionary<string, HighlightColor>
             {
                 ["Default"] = new HighlightBackground(nameof(SystemColors.WindowText), nameof(SystemColors.Window), bold: false, italic: false),
-                ["Selection"] = new HighlightColor(SystemColors.HighlightText, Color.FromArgb(0xc3, 0xc3, 0xff), bold: false, italic: false),
+                ["Selection"] = new HighlightColor(SystemColors.WindowText, Color.FromArgb(0xc3, 0xc3, 0xff), bold: false, italic: false),
                 ["VRuler"] = new HighlightColor(nameof(SystemColors.ControlLight), nameof(SystemColors.Window), bold: false, italic: false),
                 ["InvalidLines"] = new HighlightColor(Color.FromArgb(0xB6, 0xB6, 0xC0), bold: false, italic: false),
                 ["CaretMarker"] = new HighlightColor(nameof(SystemColors.MenuBar), bold: false, italic: false),


### PR DESCRIPTION
Remove the environment highlight color for all languages. For most colors, the value was the same in the defaults already, a few colors were updated in the defaults instead. Therefore, this only have minor impact on languages without specific strategy

This improves theming too, system colors do not have to be adapted.

The following was slightly changed:
VRuler E0E0E5 -> ControlLight (e3e3e3)
CaretMarker f0f0f1 -> MenuBar(f0f0f0)

A few formats were using other than the default for a few colors, like LineNumberControl in .rc "Resource" files and SpaceMarkers, TabMarkers, InvalidLines in .hx Haxe files.