### PR TITLE
feat: space as pagedown in read-only

### DIFF
--- a/Project/Src/Actions/MiscActions.cs
+++ b/Project/Src/Actions/MiscActions.cs
@@ -655,6 +655,36 @@ namespace ICSharpCode.TextEditor.Actions
         }
     }
 
+    public class Space : AbstractEditAction
+    {
+        /// <remarks>
+        ///     Executes this edit action
+        /// </remarks>
+        /// <param name="textArea">The <see cref="ItextArea" /> which is used for callback purposes</param>
+        public override void Execute(TextArea textArea)
+        {
+            if (!textArea.Document.ReadOnly)
+                return;
+
+            (new MovePageDown()).Execute(textArea);
+        }
+    }
+
+    public class ShiftSpace : AbstractEditAction
+    {
+        /// <remarks>
+        ///     Executes this edit action
+        /// </remarks>
+        /// <param name="textArea">The <see cref="ItextArea" /> which is used for callback purposes</param>
+        public override void Execute(TextArea textArea)
+        {
+            if (!textArea.Document.ReadOnly)
+                return;
+
+            (new MovePageUp()).Execute(textArea);
+        }
+    }
+
     public class Return : AbstractEditAction
     {
         /// <remarks>

--- a/Project/Src/Gui/TextArea.cs
+++ b/Project/Src/Gui/TextArea.cs
@@ -803,7 +803,7 @@ namespace ICSharpCode.TextEditor
                 return true;
 
             // if not (or the process was 'silent', use the standard edit actions
-            var action = MotherTextEditorControl?.GetEditAction(keyData);
+            var action = MotherTextEditorControl?.GetEditAction(keyData, Document.ReadOnly);
             AutoClearSelection = true;
             if (action != null)
             {

--- a/Project/Src/Gui/TextEditorControlBase.cs
+++ b/Project/Src/Gui/TextEditorControlBase.cs
@@ -36,6 +36,7 @@ namespace ICSharpCode.TextEditor
         ///     action.
         /// </summary>
         protected Dictionary<Keys, IEditAction> editactions = new Dictionary<Keys, IEditAction>();
+        protected HashSet<Keys> readonlyactions = new HashSet<Keys>();
 
         private Encoding encoding;
         private int updateLevel;
@@ -183,14 +184,14 @@ namespace ICSharpCode.TextEditor
             }
         }
 
-        public bool IsEditAction(Keys keyData)
+        public bool IsEditAction(Keys keyData, bool readOnly)
         {
-            return editactions.ContainsKey(keyData);
+            return editactions.ContainsKey(keyData) && (readOnly || !readonlyactions.Contains(keyData));
         }
 
-        internal IEditAction GetEditAction(Keys keyData)
+        internal IEditAction GetEditAction(Keys keyData, bool readOnly)
         {
-            if (!IsEditAction(keyData))
+            if (!IsEditAction(keyData, readOnly))
                 return null;
             return editactions[keyData];
         }
@@ -231,6 +232,10 @@ namespace ICSharpCode.TextEditor
             editactions[Keys.PageUp | Keys.Shift] = new ShiftMovePageUp();
             editactions[Keys.PageDown] = new MovePageDown();
             editactions[Keys.PageDown | Keys.Shift] = new ShiftMovePageDown();
+            editactions[Keys.Space] = new Space();
+            readonlyactions.Add(Keys.Space);
+            editactions[Keys.Space | Keys.Shift] = new ShiftSpace();
+            readonlyactions.Add(Keys.Space | Keys.Shift);
 
             editactions[Keys.Return] = new Return();
             editactions[Keys.Tab] = new Tab();

--- a/Project/Src/Gui/TextEditorControlBase.cs
+++ b/Project/Src/Gui/TextEditorControlBase.cs
@@ -36,7 +36,12 @@ namespace ICSharpCode.TextEditor
         ///     action.
         /// </summary>
         protected Dictionary<Keys, IEditAction> editactions = new Dictionary<Keys, IEditAction>();
-        protected HashSet<Keys> readonlyactions = new HashSet<Keys>();
+
+        /// <summary>
+        ///    Key combinations for actions only available in read-only mode.
+        ///    In read-write these keys are ignored.
+        /// </summary>
+        protected HashSet<Keys> readonlyactions = new();
 
         private Encoding encoding;
         private int updateLevel;


### PR DESCRIPTION
Similar shift-space as pageup, as in browsers etc.

Note: I would like to scroll to next file in diff lists with space too, but that need to be handled in the app.
Just as scroll, the app may override the input (similar for pagedown).

This after a few days using a laptop without a scrollwheel mouse. How can you work on a laptop?