### PR TITLE
fix: limit linenumber gutter margin

### DIFF
--- a/Project/Src/Gui/GutterMargin.cs
+++ b/Project/Src/Gui/GutterMargin.cs
@@ -42,7 +42,7 @@ namespace ICSharpCode.TextEditor
         public override Cursor Cursor => RightLeftCursor;
 
         public override int Width
-            => textArea.TextView.WideSpaceWidth*Math.Max(4, (int)Math.Log10(textArea.Document.TotalNumberOfLines) + 4);
+            => textArea.TextView.WideSpaceWidth*Math.Max(2, (int)Math.Log10(textArea.Document.TotalNumberOfLines) + 1);
 
         public override bool IsVisible => textArea.TextEditorProperties.ShowLineNumbers;
 

--- a/Project/Src/Gui/GutterMargin.cs
+++ b/Project/Src/Gui/GutterMargin.cs
@@ -42,7 +42,7 @@ namespace ICSharpCode.TextEditor
         public override Cursor Cursor => RightLeftCursor;
 
         public override int Width
-            => textArea.TextView.WideSpaceWidth*Math.Max(2, (int)Math.Log10(textArea.Document.TotalNumberOfLines) + 1);
+            => textArea.TextView.WideSpaceWidth * (2 * (int)Math.Log10(textArea.Document.TotalNumberOfLines) + 3) / 2;
 
         public override bool IsVisible => textArea.TextEditorProperties.ShowLineNumbers;
 


### PR DESCRIPTION
Change the line number gutter adds a 4 digit margin (with blank) to 1 digit.
Note that diff displays have a trimmed margin with 0 digits

Note that in the default theme the lineno gutter is rendered with the same background as the test, so some limit is required there.

Before:

![image](https://github.com/user-attachments/assets/bbfe458f-3c09-44e9-be30-15086b403cbe)

![image](https://github.com/user-attachments/assets/e89cd5c8-f64f-46aa-9eee-2bccaede9720)

![image](https://github.com/user-attachments/assets/c41a80da-a28a-46db-a995-d8a97f3fc2e3)

![image](https://github.com/user-attachments/assets/161c5e61-2480-4bbc-ab8d-01d630c8acb9)

After:

![image](https://github.com/user-attachments/assets/aa1a3919-2936-4d61-a919-81416ce6e002)
![image](https://github.com/user-attachments/assets/fede5f57-b1ed-49cc-b924-07fbf11b9c4c)

If you are used to having a big margin, the following will require that you aclearn the change (should be quick)
![image](https://github.com/user-attachments/assets/24977cba-ff98-478d-8184-08088558eba6)

Note that there is no margin at all at "max length" 
![image](https://github.com/user-attachments/assets/53d59385-0e4b-4eae-b4e1-e576b4c1f72b)

![image](https://github.com/user-attachments/assets/b5156ba3-7784-4de0-906d-22ed4b963665)

![image](https://github.com/user-attachments/assets/96e3c7ad-8c1d-4f95-8fe1-12202d135569)
