### PR TITLE
fix(GutterMargin): Align linenumbers with text

### DIFF
--- a/Project/Src/Gui/GutterMargin.cs
+++ b/Project/Src/Gui/GutterMargin.cs
@@ -34,7 +34,7 @@ namespace ICSharpCode.TextEditor
 
         public GutterMargin(TextArea textArea) : base(textArea)
         {
-            numberStringFormat.LineAlignment = StringAlignment.Far;
+            numberStringFormat.LineAlignment = StringAlignment.Near;
             numberStringFormat.FormatFlags = StringFormatFlags.MeasureTrailingSpaces | StringFormatFlags.FitBlackBox |
                                              StringFormatFlags.NoWrap | StringFormatFlags.NoClip;
         }


### PR DESCRIPTION
fix(GutterMargin): Align linenumbers with the text area by choosing the matching `numberStringFormat.LineAlignment`