### PR TITLE
fix(TextView): Clamp FirstVisibleLine

### DIFF
--- a/Project/Src/Gui/TextView.cs
+++ b/Project/Src/Gui/TextView.cs
@@ -43,8 +43,10 @@ namespace ICSharpCode.TextEditor
             get => textArea.Document.GetFirstLogicalLine(textArea.VirtualTop.Y/FontHeight);
             set
             {
-                if (FirstVisibleLine != value)
-                    textArea.VirtualTop = new Point(textArea.VirtualTop.X, textArea.Document.GetVisibleLine(value)*FontHeight);
+                // Clamp the value in order to avoid scrolling the text out of view
+                int clampedValue = Math.Max(0, Math.Min(value, textArea.Document.TotalNumberOfLines - textArea.TextView.VisibleLineCount + 1));
+                if (FirstVisibleLine != clampedValue)
+                    textArea.VirtualTop = new Point(textArea.VirtualTop.X, textArea.Document.GetVisibleLine(clampedValue) * FontHeight);
             }
         }
 


### PR DESCRIPTION
Hopefully fixes: At a first glance, it looked like no diff was displayed under some circumstances, which occurred several times in a new project at work (WSL?).
Though, those diffs were just scrolled to the very bottom.

### Proposed changes

`TextView`: Clamp `FirstVisibleLine` instead of effectively displaying nothing

### Before

![image](https://github.com/user-attachments/assets/04000e8e-7396-4f1e-92ae-b4f0f28c9912)

### After

![image](https://github.com/user-attachments/assets/7ce1fbb1-5fa8-4fa2-b03e-cef0eff94965)

