### PR TITLE
Fix scrollbar jitter and not appearing when they should

### DIFF
--- a/Project/Src/Gui/TextAreaControl.cs
+++ b/Project/Src/Gui/TextAreaControl.cs
@@ -159,7 +159,7 @@ namespace ICSharpCode.TextEditor
         {
             if (lineLengthCache != null)
             {
-                if (lineLengthCache.Length < Document.TotalNumberOfLines + 2*LineLengthCacheAdditionalSize)
+                if (lineLengthCache.Length < Document.TotalNumberOfLines + 2 * LineLengthCacheAdditionalSize)
                     lineLengthCache = null;
                 else
                     Array.Clear(lineLengthCache, index: 0, lineLengthCache.Length);
@@ -180,6 +180,8 @@ namespace ICSharpCode.TextEditor
             var newVisibilities = ComputeScrollBarVisibilities(bounds.textArea.Size);
             bounds = Measure(newVisibilities.visibilities);
             ApplyLayout(newVisibilities.visibilities, newVisibilities.maxLength, bounds);
+
+            return;
 
             static ScrollVisibilities GetScrollVisibilities(bool h, bool v)
             {
@@ -244,7 +246,7 @@ namespace ICSharpCode.TextEditor
 
                 var partialLineHeightVisibleAtTheTop = (view.FontHeight - VScrollBar.Value % view.FontHeight) % view.FontHeight;
 
-                var visibleLineCount = (int)Math.Ceiling(((double)size.Height - partialLineHeightVisibleAtTheTop + hScrollBarHeightAdjustment)/view.FontHeight);
+                var visibleLineCount = (int)Math.Ceiling(((double)size.Height - partialLineHeightVisibleAtTheTop + hScrollBarHeightAdjustment) / view.FontHeight);
                 visibleLineCount += partialLineHeightVisibleAtTheTop > 0 ? 1 : 0;
                 var vScrollBarVisible = VScrollBar.Value != 0 || TextArea.Document.TotalNumberOfLines >= visibleLineCount || VScrollBar.IsMouseDown;
 
@@ -256,7 +258,7 @@ namespace ICSharpCode.TextEditor
                     // calculation was done with adjustments to account for that. Here we take the actual Height
                     // (which is reduced due to the HScrollBar) and see if that would require a VScrollBar.
 
-                    var visibleLineCountNoAdjustment = (int)Math.Ceiling(((double)size.Height - partialLineHeightVisibleAtTheTop)/view.FontHeight);
+                    var visibleLineCountNoAdjustment = (int)Math.Ceiling(((double)size.Height - partialLineHeightVisibleAtTheTop) / view.FontHeight);
                     visibleLineCountNoAdjustment += partialLineHeightVisibleAtTheTop > 0 ? 1 : 0;
                     hScrollBarWouldCauseVScrollBar = TextArea.Document.TotalNumberOfLines >= visibleLineCountNoAdjustment;
                 }
@@ -265,7 +267,7 @@ namespace ICSharpCode.TextEditor
                     ? SystemInformation.VerticalScrollBarWidth
                     : 0;
 
-                var visibleColumnCount = (int)Math.Floor(((double)size.Width + vScrollBarWidthAdjustment)/view.WideSpaceWidth);
+                var visibleColumnCount = (int)Math.Floor(((double)size.Width + vScrollBarWidthAdjustment) / view.WideSpaceWidth);
 
                 var firstLineIndex = view.FirstVisibleLine;
 
@@ -304,7 +306,7 @@ namespace ICSharpCode.TextEditor
 
             void ApplyLayout(ScrollVisibilities scrollVisibilities, int maxColumn, (Rectangle hRule, Rectangle textControl, Rectangle textArea, Rectangle hScroll, Rectangle vScroll) bounds)
             {
-                var visibleColumnCount = bounds.textArea.Width/view.WideSpaceWidth - 1;
+                var visibleColumnCount = bounds.textArea.Width / view.WideSpaceWidth - 1;
 
                 VScrollBar.SuspendLayout();
                 VScrollBar.Minimum = 0;
@@ -371,7 +373,7 @@ namespace ICSharpCode.TextEditor
 
         private void HScrollBarValueChanged(object sender, EventArgs e)
         {
-            TextArea.VirtualTop = new Point(HScrollBar.Value*TextArea.TextView.WideSpaceWidth, TextArea.VirtualTop.Y);
+            TextArea.VirtualTop = new Point(HScrollBar.Value * TextArea.TextView.WideSpaceWidth, TextArea.VirtualTop.Y);
             TextArea.Invalidate();
         }
 
@@ -397,12 +399,12 @@ namespace ICSharpCode.TextEditor
                     scrollDistance = -scrollDistance;
                 if (hScroll || ModifierKeys.HasFlag(Keys.Shift))
                 {
-                    var newValue = HScrollBar.Value + HScrollBar.SmallChange*scrollDistance;
+                    var newValue = HScrollBar.Value + HScrollBar.SmallChange * scrollDistance;
                     HScrollBar.Value = Math.Max(HScrollBar.Minimum, Math.Min(HScrollBar.Maximum - HScrollBar.LargeChange + 1, newValue));
                 }
                 else
                 {
-                    var newValue = VScrollBar.Value + VScrollBar.SmallChange*scrollDistance;
+                    var newValue = VScrollBar.Value + VScrollBar.SmallChange * scrollDistance;
                     VScrollBar.Value = Math.Max(VScrollBar.Minimum, Math.Min(VScrollBar.Maximum - VScrollBar.LargeChange + 1, newValue));
                 }
             }
@@ -495,7 +497,7 @@ namespace ICSharpCode.TextEditor
 
             if (line - scrollMarginHeight + 3 < curLineMin)
             {
-                VScrollBar.Value = Math.Max(0, Math.Min(VScrollBar.Maximum, (line - scrollMarginHeight + 3)*TextArea.TextView.FontHeight));
+                VScrollBar.Value = Math.Max(0, Math.Min(VScrollBar.Maximum, (line - scrollMarginHeight + 3) * TextArea.TextView.FontHeight));
                 VScrollBarValueChanged(this, EventArgs.Empty);
             }
             else
@@ -504,11 +506,11 @@ namespace ICSharpCode.TextEditor
                 if (line + scrollMarginHeight - 1 > curLineMax)
                 {
                     if (TextArea.TextView.VisibleLineCount == 1)
-                        VScrollBar.Value = Math.Max(0, Math.Min(VScrollBar.Maximum, (line - scrollMarginHeight - 1)*TextArea.TextView.FontHeight));
+                        VScrollBar.Value = Math.Max(0, Math.Min(VScrollBar.Maximum, (line - scrollMarginHeight - 1) * TextArea.TextView.FontHeight));
                     else
                         VScrollBar.Value = Math.Min(
                             VScrollBar.Maximum,
-                            (line - TextArea.TextView.VisibleLineCount + scrollMarginHeight - 1)*TextArea.TextView.FontHeight);
+                            (line - TextArea.TextView.VisibleLineCount + scrollMarginHeight - 1) * TextArea.TextView.FontHeight);
                     VScrollBarValueChanged(this, EventArgs.Empty);
                 }
             }
@@ -529,7 +531,7 @@ namespace ICSharpCode.TextEditor
             // convert line to visible line:
             line = Document.GetVisibleLine(line);
             // subtract half the visible line count
-            line -= TextArea.TextView.VisibleLineCount/2;
+            line -= TextArea.TextView.VisibleLineCount / 2;
 
             var curLineMin = TextArea.TextView.FirstPhysicalLine;
             if (TextArea.TextView.LineHeightRemainder > 0)
@@ -537,7 +539,7 @@ namespace ICSharpCode.TextEditor
             if (Math.Abs(curLineMin - line) > treshold)
             {
                 // scroll:
-                VScrollBar.Value = Math.Max(0, Math.Min(VScrollBar.Maximum, (line - scrollMarginHeight + 3)*TextArea.TextView.FontHeight));
+                VScrollBar.Value = Math.Max(0, Math.Min(VScrollBar.Maximum, (line - scrollMarginHeight + 3) * TextArea.TextView.FontHeight));
                 VScrollBarValueChanged(this, EventArgs.Empty);
             }
         }

--- a/Project/Src/Gui/TrackableVScrollBar.cs
+++ b/Project/Src/Gui/TrackableVScrollBar.cs
@@ -1,0 +1,49 @@
+﻿using System.Windows.Forms;
+
+namespace ICSharpCode.TextEditor;
+
+/// <summary>
+/// A vertical scrollbar control that tracks mouse down events to detect when the user is actively dragging the scrollbar.
+/// </summary>
+public class TrackableVScrollBar : VScrollBar
+{
+    const int WM_LBUTTONDOWN = 0x0201;
+
+    /// <summary>
+    /// Gets a value indicating whether the mouse button is currently pressed down on the scrollbar.
+    /// </summary>
+    public bool IsMouseDown { get; private set; }
+
+    public TrackableVScrollBar()
+    {
+        this.Scroll += VScrollBar_Scroll;
+    }
+
+    /// <summary>
+    /// Occurs when the user finishes scrolling and releases the mouse button.
+    /// </summary>
+    public event ScrollEventHandler MouseScrollEnded;
+
+    private void VScrollBar_Scroll(object sender, ScrollEventArgs e)
+    {
+        if (e.Type == ScrollEventType.EndScroll)
+        {
+            if (IsMouseDown)
+            {
+                IsMouseDown = false;
+
+                MouseScrollEnded?.Invoke(this, e);
+            }
+        }
+    }
+
+    protected override void WndProc(ref Message m)
+    {
+        if (m.Msg == WM_LBUTTONDOWN)
+        {
+            IsMouseDown = true;
+        }
+
+        base.WndProc(ref m);
+    }
+}

--- a/Project/Src/Gui/TrackableVScrollBar.cs
+++ b/Project/Src/Gui/TrackableVScrollBar.cs
@@ -3,19 +3,19 @@
 namespace ICSharpCode.TextEditor;
 
 /// <summary>
-/// A vertical scrollbar control that tracks mouse down events to detect when the user is actively dragging the scrollbar.
+///  A vertical scrollbar control that tracks mouse down events to detect when the user is actively dragging the scrollbar.
 /// </summary>
 public class TrackableVScrollBar : VScrollBar
 {
     const int WM_LBUTTONDOWN = 0x0201;
 
     /// <summary>
-    /// Gets a value indicating whether the mouse button is currently pressed down on the scrollbar.
+    ///  Gets a value indicating whether the mouse button is currently pressed down on the scrollbar.
     /// </summary>
     public bool IsMouseDown { get; private set; }
 
     /// <summary>
-    /// Occurs when the user finishes scrolling and releases the mouse button.
+    ///  Occurs when the user finishes scrolling and releases the mouse button.
     /// </summary>
     public event ScrollEventHandler MouseScrollEnded;
 
@@ -36,6 +36,7 @@ public class TrackableVScrollBar : VScrollBar
 
     protected override void WndProc(ref Message m)
     {
+        // VScrollBar control doesn't trigger OnMouseDown, so we need to handle the message directly.
         if (m.Msg == WM_LBUTTONDOWN)
         {
             IsMouseDown = true;

--- a/Project/Src/Gui/TrackableVScrollBar.cs
+++ b/Project/Src/Gui/TrackableVScrollBar.cs
@@ -14,17 +14,12 @@ public class TrackableVScrollBar : VScrollBar
     /// </summary>
     public bool IsMouseDown { get; private set; }
 
-    public TrackableVScrollBar()
-    {
-        this.Scroll += VScrollBar_Scroll;
-    }
-
     /// <summary>
     /// Occurs when the user finishes scrolling and releases the mouse button.
     /// </summary>
     public event ScrollEventHandler MouseScrollEnded;
 
-    private void VScrollBar_Scroll(object sender, ScrollEventArgs e)
+    protected override void OnScroll(ScrollEventArgs e)
     {
         if (e.Type == ScrollEventType.EndScroll)
         {
@@ -35,6 +30,8 @@ public class TrackableVScrollBar : VScrollBar
                 MouseScrollEnded?.Invoke(this, e);
             }
         }
+
+        base.OnScroll(e);
     }
 
     protected override void WndProc(ref Message m)

--- a/Test/ICSharpCode.TextEditor.Tests.csproj
+++ b/Test/ICSharpCode.TextEditor.Tests.csproj
@@ -20,6 +20,7 @@
 
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" IsImplicitlyDefined="true" />
 
+    <PackageReference Include="FluentAssertions" Version="8.8.0" />
     <PackageReference Include="NUnit" Version="3.13.2" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.12.0" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" IsImplicitlyDefined="true" PrivateAssets="all" Publish="true" />

--- a/Test/TextEditorControl/ScrollBarTests.cs
+++ b/Test/TextEditorControl/ScrollBarTests.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Threading;
-using System.Threading.Tasks;
 using System.Windows.Forms;
+using FluentAssertions;
 using NUnit.Framework;
 
 namespace ICSharpCode.TextEditor.Tests.TextEditorControl;
@@ -20,7 +20,7 @@ public class ScrollBarTests
     }
 
     [Test]
-    public async Task TextEditorControl_with_text_requiring_both_scrollbars_should_show_both()
+    public void TextEditorControl_with_text_requiring_both_scrollbars_should_show_both()
     {
         SetupForm(width: 300, height: 276);
 
@@ -43,12 +43,12 @@ public class ScrollBarTests
 
         Application.DoEvents();
 
-        Assert.That(_textEditorControl.ActiveTextAreaControl.VScrollBar.Visible, Is.True);
-        Assert.That(_textEditorControl.ActiveTextAreaControl.HScrollBar.Visible, Is.True);
+        _textEditorControl.ActiveTextAreaControl.VScrollBar.Visible.Should().BeTrue();
+        _textEditorControl.ActiveTextAreaControl.HScrollBar.Visible.Should().BeTrue();
     }
 
     [Test]
-    public async Task TextEditorControl_with_last_partialy_hidden_by_horizontal_scrollbar_should_cause_vertical_scrollbar()
+    public void TextEditorControl_with_last_partialy_hidden_by_horizontal_scrollbar_should_cause_vertical_scrollbar()
     {
         SetupForm(width: 300, height: 270);
 
@@ -70,12 +70,12 @@ public class ScrollBarTests
 
         Application.DoEvents();
 
-        Assert.That(_textEditorControl.ActiveTextAreaControl.VScrollBar.Visible, Is.True);
-        Assert.That(_textEditorControl.ActiveTextAreaControl.HScrollBar.Visible, Is.True);
+        _textEditorControl.ActiveTextAreaControl.VScrollBar.Visible.Should().BeTrue();
+        _textEditorControl.ActiveTextAreaControl.HScrollBar.Visible.Should().BeTrue();
     }
 
     [Test]
-    public async Task TextEditorControl_with_partial_lines_at_top_and_bottom_should_take_last_lines_width_into_account()
+    public void TextEditorControl_with_partial_lines_at_top_and_bottom_should_take_last_lines_width_into_account()
     {
         SetupForm(width: 300, height: 238);
 
@@ -101,12 +101,12 @@ public class ScrollBarTests
 
         Application.DoEvents();
 
-        Assert.That(_textEditorControl.ActiveTextAreaControl.VScrollBar.Visible, Is.True);
-        Assert.That(_textEditorControl.ActiveTextAreaControl.HScrollBar.Visible, Is.True);
+        _textEditorControl.ActiveTextAreaControl.VScrollBar.Visible.Should().BeTrue();
+        _textEditorControl.ActiveTextAreaControl.HScrollBar.Visible.Should().BeTrue();
     }
 
     [Test]
-    public async Task TextEditorControl_with_vScrollBar_should_have_no_scrollbars_if_not_necessary_after_update()
+    public void TextEditorControl_with_vScrollBar_should_have_no_scrollbars_if_not_necessary_after_update()
     {
         SetupForm(width: 300, height: 250);
 
@@ -130,8 +130,8 @@ public class ScrollBarTests
 
         Application.DoEvents();
 
-        Assert.That(_textEditorControl.ActiveTextAreaControl.VScrollBar.Visible, Is.False);
-        Assert.That(_textEditorControl.ActiveTextAreaControl.HScrollBar.Visible, Is.False);
+        _textEditorControl.ActiveTextAreaControl.VScrollBar.Visible.Should().BeFalse();
+        _textEditorControl.ActiveTextAreaControl.HScrollBar.Visible.Should().BeFalse();
     }
 
     private void SetupForm(int width, int height)

--- a/Test/TextEditorControl/ScrollBarTests.cs
+++ b/Test/TextEditorControl/ScrollBarTests.cs
@@ -1,0 +1,150 @@
+﻿using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using NUnit.Framework;
+
+namespace ICSharpCode.TextEditor.Tests.TextEditorControl;
+
+[TestFixture]
+[Apartment(ApartmentState.STA)]
+public class ScrollBarTests
+{
+    private Form _form;
+    private ICSharpCode.TextEditor.TextEditorControl _textEditorControl;
+
+    [TearDown]
+    public void TearDown()
+    {
+        _form.Dispose();
+    }
+
+    [Test]
+    public async Task TextEditorControl_with_text_requiring_both_scrollbars_should_show_both()
+    {
+        SetupForm(width: 300, height: 276);
+
+        _textEditorControl.Text = """
+          This is a
+          multi
+          row
+          text
+          to
+          almost
+          get
+          a
+          scrollbar
+          at a
+          bottom row
+          which
+          is
+          lower and very long and would only show HScrollBar while visible, but would get invisible once the HScrollBar is visible
+          """;
+
+        Application.DoEvents();
+
+        Assert.That(_textEditorControl.ActiveTextAreaControl.VScrollBar.Visible, Is.True);
+        Assert.That(_textEditorControl.ActiveTextAreaControl.HScrollBar.Visible, Is.True);
+    }
+
+    [Test]
+    public async Task TextEditorControl_with_last_partialy_hidden_by_horizontal_scrollbar_should_cause_vertical_scrollbar()
+    {
+        SetupForm(width: 300, height: 270);
+
+        _textEditorControl.Text = """
+          This is a
+          multi
+          row
+          text
+          positioned
+          to
+          only
+          show
+          last
+          line
+          partially
+          which
+          should still cause VScrollBar to be visible. Some more text to make this line really long.
+          """;
+
+        Application.DoEvents();
+
+        Assert.That(_textEditorControl.ActiveTextAreaControl.VScrollBar.Visible, Is.True);
+        Assert.That(_textEditorControl.ActiveTextAreaControl.HScrollBar.Visible, Is.True);
+    }
+
+    [Test]
+    public async Task TextEditorControl_with_partial_lines_at_top_and_bottom_should_take_last_lines_width_into_account()
+    {
+        SetupForm(width: 300, height: 238);
+
+        _textEditorControl.Text = """
+          This is a
+          multi
+          row
+          text
+          scrolled
+          to show only some
+          line
+          at
+          the top
+          and a very long line
+          at
+          the bottom
+          thus if you have 0.1 line at the top, 0.1 line at the bottom and 3 lines in between, you should calculate the width of 5 lines.
+          """;
+
+        Application.DoEvents();
+
+        _textEditorControl.ActiveTextAreaControl.VScrollBar.Value = 12;
+
+        Application.DoEvents();
+
+        Assert.That(_textEditorControl.ActiveTextAreaControl.VScrollBar.Visible, Is.True);
+        Assert.That(_textEditorControl.ActiveTextAreaControl.HScrollBar.Visible, Is.True);
+    }
+
+    [Test]
+    public async Task TextEditorControl_with_vScrollBar_should_have_no_scrollbars_if_not_necessary_after_update()
+    {
+        SetupForm(width: 300, height: 250);
+
+        // First, set text to require vertical scrollbar
+        _textEditorControl.Text = string.Join("\r\n", Enumerable.Repeat("a", 16));
+
+        _textEditorControl.Text = """
+          This is a line that would fit
+          without a VScrollBar
+          but now it doesn't.
+          Also
+          this
+          text
+          is
+          long
+          enough
+          to
+          "threatten"
+          a VScrollBar
+          """;
+
+        Application.DoEvents();
+
+        Assert.That(_textEditorControl.ActiveTextAreaControl.VScrollBar.Visible, Is.False);
+        Assert.That(_textEditorControl.ActiveTextAreaControl.HScrollBar.Visible, Is.False);
+    }
+
+    private void SetupForm(int width, int height)
+    {
+        _form = new Form
+        {
+            Width = width,
+            Height = height,
+        };
+        _textEditorControl = new TextEditor.TextEditorControl { Parent = _form, Dock = DockStyle.Fill };
+
+        _form.Show();
+
+        Application.DoEvents();
+    }
+}


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md before submitting a pull request -->

Fixes #4 and #53

Root cause for #4 only occurs when using a mouse cursor to drag the vertical scrollbar. If during drag a horizontal scrollbar is shown or hidden the text part of `TextAreaControl` gets resized by the appearance or disappearance of the scrollbar at the bottom. At the same time mouse cursor which drags the vertical scrollbar remains in the same place (adjusted for the dragging itself). This causes the vertical scrollbar to effectively get moved as the whole control "moves" under it while dragging is active.

`Notepad++` solves this by keeping the horizontal scrollbar forever if it's shown at least once.

> [!NOTE]
> This only applies to click+drag scrolling. Scroll-wheel or touch-pad scrolling is not affected 

#53 was caused by being unable to reach a "stable" state when trying to determine necessary scrollbars. e.g. 1) you need a horizontal scrollbar 2) horizontal scrollbar hides the longest line which caused it 3) hide horizontal scrollbar .. back to 1).

## Proposed changes

- Track the state of whether the mouse is still down on the scrollbar during the drag process (accomplished by `TrackableVScrollBar`)
  - Only allow horizontal scrollbar to be hidden if mouse-drag is not active
- Change scrollbar visibility calculation to need just one pass thus avoiding looking for "stable" scrollbar configuration

## Test methodology <!-- How did you ensure quality? -->

- Unit tests
- Used this daily for at least a month

## Merge strategy

I agree that the maintainer squash merge this PR (if the commit message is clear).
