### PR TITLE
fix(VisibleLinesCount): Consider HScrollBar

### DIFF
--- a/Project/Src/Gui/TextAreaControl.cs
+++ b/Project/Src/Gui/TextAreaControl.cs
@@ -508,9 +508,14 @@ namespace ICSharpCode.TextEditor
                     if (TextArea.TextView.VisibleLineCount == 1)
                         VScrollBar.Value = Math.Max(0, Math.Min(VScrollBar.Maximum, (line - scrollMarginHeight - 1) * TextArea.TextView.FontHeight));
                     else
+                    {
+                        int possibleHeightLoss = HScrollBar.Visible ? 0 : SystemInformation.HorizontalScrollBarHeight;
+                        int fontHeight = TextArea.TextView.FontHeight;
+                        int completelyVisibleLinesCount = (TextArea.TextView.DrawingPosition.Height - possibleHeightLoss) / fontHeight;
                         VScrollBar.Value = Math.Min(
                             VScrollBar.Maximum,
-                            (line - TextArea.TextView.VisibleLineCount + scrollMarginHeight - 1) * TextArea.TextView.FontHeight);
+                            (line - completelyVisibleLinesCount + scrollMarginHeight - 1) * fontHeight);
+                    }
                     VScrollBarValueChanged(this, EventArgs.Empty);
                 }
             }

--- a/Project/Src/Gui/TextView.cs
+++ b/Project/Src/Gui/TextView.cs
@@ -38,17 +38,7 @@ namespace ICSharpCode.TextEditor
         public int LineHeightRemainder => textArea.VirtualTop.Y%FontHeight;
 
         /// <summary>Gets the first visible <b>logical</b> line.</summary>
-        public int FirstVisibleLine
-        {
-            get => textArea.Document.GetFirstLogicalLine(textArea.VirtualTop.Y/FontHeight);
-            set
-            {
-                // Clamp the value in order to avoid scrolling the text out of view
-                int clampedValue = Math.Max(0, Math.Min(value, textArea.Document.TotalNumberOfLines - textArea.TextView.VisibleLineCount + 1));
-                if (FirstVisibleLine != clampedValue)
-                    textArea.VirtualTop = new Point(textArea.VirtualTop.X, textArea.Document.GetVisibleLine(clampedValue) * FontHeight);
-            }
-        }
+        public int FirstVisibleLine => textArea.Document.GetFirstLogicalLine(textArea.VirtualTop.Y/FontHeight);
 
         public int VisibleLineDrawingRemainder => textArea.VirtualTop.Y%FontHeight;
 
@@ -1135,5 +1125,26 @@ namespace ICSharpCode.TextEditor
         }
 
         #endregion
+
+        /// <summary>
+        ///  Sets the first visible <b>logical</b> line.
+        /// </summary>
+        /// <param name="lineIndex">
+        ///  The logical line which should be the top line.
+        ///  The value is clamped in order to avoid scrolling the text out of view.
+        /// </param>
+        /// <param name="possibleHeightLoss">
+        ///  A horizontal scrollbar might be needed and would reduce the number of visible lines.
+        ///  Pass the height scrollbar height if it should be considered when clamping <paramref name="lineIndex"/>.
+        /// </param>
+        public void SetFirstVisibleLine(int lineIndex, int possibleHeightLoss = 0)
+        {
+            int completelyVisibleLineCount = (DrawingPosition.Height - possibleHeightLoss) / FontHeight;
+            int clampedValue = Math.Max(0, Math.Min(lineIndex, textArea.Document.TotalNumberOfLines - completelyVisibleLineCount));
+            if (FirstVisibleLine != clampedValue)
+            {
+                textArea.VirtualTop = new Point(textArea.VirtualTop.X, textArea.Document.GetVisibleLine(clampedValue) * FontHeight);
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes search hit being hidden by HScrollBar, also seen with git-grep

### Proposed changes

- `TextView.FirstVisibleLine`: Replace setter with `SetFirstVisibleLine`
  which considers `possibleHeightLoss` because the horizontal scrollbar might become visible
- `TextAreaControl.ScrollTo`: Calculate `completelyVisibleLinesCount` and consider that the horizontal scrollbar might become visible

### Screenshots

STR:
- select commit ae1340d3614c5affab0d828946c44e5e694d4bcd
- select file src/app/GitUI/UserControls/FileStatusDiffCalculator.cs
- search for "without HEAD"

#### Before

<img width="1648" height="566" alt="image" src="https://github.com/user-attachments/assets/e8c1c54b-fbb4-4180-b899-e85436915b2c" />

#### After

<img width="1648" height="566" alt="image" src="https://github.com/user-attachments/assets/3363a625-2d28-4f7e-9779-4ce408b9d9df" />