### PR TITLE
feat: Add syntax highlighting for .slnx and .vsconfig files

### DIFF
--- a/Project/Resources/JSON.xshd
+++ b/Project/Resources/JSON.xshd
@@ -10,7 +10,7 @@ hello@exr.be
 https://github.com/ei
 -->
 
-<SyntaxDefinition name="JSON" extensions=".json">
+<SyntaxDefinition name="JSON" extensions=".json;.vsconfig">
     
     <Environment/>
     
@@ -25,7 +25,7 @@ https://github.com/ei
     <RuleSets>
         <RuleSet ignorecase="false">
         
-            <Delimiters>&amp;&lt;&gt;~%^*()-+=!|\/{}[]:;"' ,    ?</Delimiters>
+            <Delimiters>&amp;&lt;&gt;~%^*()-+=!|\/{}[]:;"' ,	?</Delimiters>
         
             <Span name="LineComment" stopateol="true" color="Green" bold="false" italic="false">
                 <Begin>//</Begin>

--- a/Project/Resources/XML.xshd
+++ b/Project/Resources/XML.xshd
@@ -10,7 +10,7 @@ hello@exr.be
 https://github.com/ei
 -->
 
-<SyntaxDefinition name="XML" extensions=".xml;.xsl;.xslt;.xhtml;.xsd;.syn;.lang;.manifest;.config;.addin;.xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.vcproj;.vcxproj;.vcxproj.filters;.resx;.user;.ilproj;.booproj;.build;.xfrm;.targets;.props;.xaml;.xpt;.xft;.map;.wsdl;.disco;.ruleset;.settings;.DotSettings;.cd;.svg;.xlf;.fodp;.fods;.fodt;.arxml">
+<SyntaxDefinition name="XML" extensions=".xml;.xsl;.xslt;.xhtml;.xsd;.syn;.lang;.manifest;.config;.addin;.xshd;.wxs;.wxi;.wxl;.proj;.csproj;.vbproj;.vcproj;.vcxproj;.vcxproj.filters;.resx;.user;.ilproj;.booproj;.build;.xfrm;.targets;.props;.xaml;.xpt;.xft;.map;.wsdl;.disco;.ruleset;.settings;.DotSettings;.cd;.svg;.xlf;.fodp;.fods;.fodt;.arxml;.slnx">
     <Environment/>
     
     <Properties>


### PR DESCRIPTION
Add file extension mappings so that `.slnx` files get XML syntax highlighting and `.vsconfig` files get JSON syntax highlighting in Git Extensions file viewers.

### Changes

- **XML.xshd** — added `.slnx` to the extensions list (`.slnx` is the new XML-based Visual Studio solution format)
- **JSON.xshd** — added `.vsconfig` to the extensions list (`.vsconfig` is a JSON file specifying VS component requirements)