### PR TITLE
Avoid string allocations at the cost of extra cache Dictionary lookup & removed unneeded Dictionary lookups elsewhere

### DIFF
--- a/Project/Src/Actions/MiscActions.cs
+++ b/Project/Src/Actions/MiscActions.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Diagnostics;
+using System.Runtime.InteropServices;
 using System.Text;
 using ICSharpCode.TextEditor.Document;
 
@@ -91,7 +92,7 @@ namespace ICSharpCode.TextEditor.Actions
             textArea.Document.UndoStack.StartUndoGroup();
             if (textArea.SelectionManager.HasSomethingSelected)
             {
-                foreach (var selection in textArea.SelectionManager.SelectionCollection)
+                foreach (ISelection selection in CollectionsMarshal.AsSpan(textArea.SelectionManager.SelectionCollection))
                 {
                     var startLine = selection.StartPosition.Y;
                     var endLine = selection.EndPosition.Y;
@@ -174,7 +175,7 @@ namespace ICSharpCode.TextEditor.Actions
         {
             if (textArea.SelectionManager.HasSomethingSelected)
             {
-                foreach (var selection in textArea.SelectionManager.SelectionCollection)
+                foreach (ISelection selection in CollectionsMarshal.AsSpan(textArea.SelectionManager.SelectionCollection))
                 {
                     var startLine = selection.StartPosition.Y;
                     var endLine = selection.EndPosition.Y;
@@ -296,25 +297,23 @@ namespace ICSharpCode.TextEditor.Actions
             if (textArea.Document.ReadOnly)
                 return;
 
-            string comment = null;
-            if (textArea.Document.HighlightingStrategy.Properties.ContainsKey("LineComment"))
-                comment = textArea.Document.HighlightingStrategy.Properties["LineComment"];
+            textArea.Document.HighlightingStrategy.Properties.TryGetValue("LineComment", out string comment);
 
-            if (comment == null || comment.Length == 0)
+            if (string.IsNullOrEmpty(comment))
                 return;
 
             textArea.Document.UndoStack.StartUndoGroup();
             if (textArea.SelectionManager.HasSomethingSelected)
             {
                 var shouldComment = true;
-                foreach (var selection in textArea.SelectionManager.SelectionCollection)
+                foreach (ISelection selection in CollectionsMarshal.AsSpan(textArea.SelectionManager.SelectionCollection))
                     if (!ShouldComment(textArea.Document, comment, selection, selection.StartPosition.Y, selection.EndPosition.Y))
                     {
                         shouldComment = false;
                         break;
                     }
 
-                foreach (var selection in textArea.SelectionManager.SelectionCollection)
+                foreach (ISelection selection in CollectionsMarshal.AsSpan(textArea.SelectionManager.SelectionCollection))
                 {
                     textArea.BeginUpdate();
                     if (shouldComment)
@@ -357,15 +356,11 @@ namespace ICSharpCode.TextEditor.Actions
             if (textArea.Document.ReadOnly)
                 return;
 
-            string commentStart = null;
-            if (textArea.Document.HighlightingStrategy.Properties.ContainsKey("BlockCommentBegin"))
-                commentStart = textArea.Document.HighlightingStrategy.Properties["BlockCommentBegin"];
+            textArea.Document.HighlightingStrategy.Properties.TryGetValue("BlockCommentBegin", out string commentStart);
 
-            string commentEnd = null;
-            if (textArea.Document.HighlightingStrategy.Properties.ContainsKey("BlockCommentEnd"))
-                commentEnd = textArea.Document.HighlightingStrategy.Properties["BlockCommentEnd"];
+            textArea.Document.HighlightingStrategy.Properties.TryGetValue("BlockCommentEnd", out string commentEnd);
 
-            if (commentStart == null || commentStart.Length == 0 || commentEnd == null || commentEnd.Length == 0)
+            if (string.IsNullOrEmpty(commentStart) || string.IsNullOrEmpty(commentEnd))
                 return;
 
             int selectionStartOffset;

--- a/Project/Src/Document/MarkerStrategy/MarkerStrategy.cs
+++ b/Project/Src/Document/MarkerStrategy/MarkerStrategy.cs
@@ -7,6 +7,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Runtime.InteropServices;
 
 namespace ICSharpCode.TextEditor.Document
 {
@@ -60,12 +61,11 @@ namespace ICSharpCode.TextEditor.Document
 
         public List<TextMarker> GetMarkers(int offset)
         {
-            if (!markersTable.ContainsKey(offset))
+            if (!markersTable.TryGetValue(offset, out List<TextMarker> markers))
             {
-                var markers = new List<TextMarker>();
-                for (var i = 0; i < textMarker.Count; ++i)
+                markers = [];
+                foreach (TextMarker marker in CollectionsMarshal.AsSpan(textMarker))
                 {
-                    var marker = textMarker[i];
                     if (marker.Offset <= offset && offset <= marker.EndOffset)
                         markers.Add(marker);
                 }
@@ -73,16 +73,15 @@ namespace ICSharpCode.TextEditor.Document
                 markersTable[offset] = markers;
             }
 
-            return markersTable[offset];
+            return markers;
         }
 
         public List<TextMarker> GetMarkers(int offset, int length)
         {
             var endOffset = offset + length - 1;
             var markers = new List<TextMarker>();
-            for (var i = 0; i < textMarker.Count; ++i)
+            foreach (TextMarker marker in CollectionsMarshal.AsSpan(textMarker))
             {
-                var marker = textMarker[i];
                 var markerOffset = marker.Offset;
                 var markerEndOffset = marker.EndOffset;
                 if ( // start in marker region

--- a/Project/Src/Gui/TextView.cs
+++ b/Project/Src/Gui/TextView.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using ICSharpCode.TextEditor.Document;
 
@@ -27,6 +28,7 @@ namespace ICSharpCode.TextEditor
 
         public TextView(TextArea textArea) : base(textArea)
         {
+            _measureCacheSpanLookup = measureCache.GetAlternateLookup<ReadOnlySpan<char>>();
             Cursor = Cursors.IBeam;
             OptionsChanged();
         }
@@ -160,7 +162,7 @@ namespace ICSharpCode.TextEditor
 
                     // search the first starting folding
                     var firstFolding = starts[index: 0];
-                    foreach (var fm in starts)
+                    foreach (FoldMarker fm in CollectionsMarshal.AsSpan(starts))
                         if (fm.StartColumn < firstFolding.StartColumn)
                             firstFolding = fm;
                     starts.Clear();
@@ -261,7 +263,7 @@ namespace ICSharpCode.TextEditor
             return physicalXPos + wordWidth + 1;
         }
 
-        private struct MarkerToDraw
+        private readonly struct MarkerToDraw
         {
             internal readonly TextMarker marker;
             internal readonly RectangleF drawingRect;
@@ -283,7 +285,7 @@ namespace ICSharpCode.TextEditor
 
         private void DrawMarkerDraw(Graphics g)
         {
-            foreach (MarkerToDraw m in markersToDraw)
+            foreach (MarkerToDraw m in CollectionsMarshal.AsSpan(markersToDraw))
             {
                 TextMarker marker = m.marker;
                 RectangleF drawingRect = m.drawingRect;
@@ -330,9 +332,9 @@ namespace ICSharpCode.TextEditor
         /// <param name="length">The length.</param>
         /// <param name="markers">All markers that have been found.</param>
         /// <returns>The Brush or null when no marker was found.</returns>
-        private static Brush? GetMarkerBrush(IList<TextMarker> markers, ref Color foreColor)
+        private static Brush? GetMarkerBrush(List<TextMarker> markers, ref Color foreColor)
         {
-            foreach (var marker in markers)
+            foreach (TextMarker marker in CollectionsMarshal.AsSpan(markers))
                 if (marker.TextMarkerType == TextMarkerType.SolidBlock)
                 {
                     if (marker.OverrideForeColor)
@@ -390,7 +392,7 @@ namespace ICSharpCode.TextEditor
                 else
                     wordForeColor = currentWord.Color;
 
-                IList<TextMarker> markers = Document.MarkerStrategy.GetMarkers(currentLine.Offset + currentWordOffset, currentWord.Length);
+                List<TextMarker> markers = Document.MarkerStrategy.GetMarkers(currentLine.Offset + currentWordOffset, currentWord.Length);
                 var wordBackBrush = GetMarkerBrush(markers, ref wordForeColor);
 
                 // It is possible that we have to split the current word because a marker/the selection begins/ends inside it
@@ -416,7 +418,7 @@ namespace ICSharpCode.TextEditor
                         splitPos = Math.Min(splitPos, selectionRange.StartColumn - currentWordOffset);
                     else if (selectionRange.EndColumn > currentWordOffset && selectionRange.EndColumn <= currentWordEndOffset)
                         splitPos = Math.Min(splitPos, selectionRange.EndColumn - currentWordOffset);
-                    foreach (var marker in markers)
+                    foreach (TextMarker marker in CollectionsMarshal.AsSpan(markers))
                     {
                         var markerColumn = marker.Offset - currentLine.Offset;
                         var markerEndColumn = marker.EndOffset - currentLine.Offset + 1; // make end offset exclusive
@@ -501,7 +503,7 @@ namespace ICSharpCode.TextEditor
                     physicalXPos += wordWidth;
                 }
 
-                foreach (var marker in markers)
+                foreach (TextMarker marker in CollectionsMarshal.AsSpan(markers))
                     if (marker.TextMarkerType != TextMarkerType.SolidBlock)
                         DrawMarker(marker, wordRectangle);
 
@@ -523,8 +525,8 @@ namespace ICSharpCode.TextEditor
             if (physicalXPos < lineRectangle.Right && endColumn >= currentLine.Length)
             {
                 // draw markers at line end
-                IList<TextMarker> markers = Document.MarkerStrategy.GetMarkers(currentLine.Offset + currentLine.Length);
-                foreach (var marker in markers)
+                List<TextMarker> markers = Document.MarkerStrategy.GetMarkers(currentLine.Offset + currentLine.Length);
+                foreach (TextMarker marker in CollectionsMarshal.AsSpan(markers))
                     if (marker.TextMarkerType != TextMarkerType.SolidBlock)
                         DrawMarker(marker, new RectangleF(physicalXPos, lineRectangle.Y, WideSpaceWidth, lineRectangle.Height));
             }
@@ -532,9 +534,9 @@ namespace ICSharpCode.TextEditor
             return physicalXPos;
         }
 
-        private int DrawDocumentWord(Graphics g, string word, Point position, Font font, Color foreColor, Brush backBrush)
+        private int DrawDocumentWord(Graphics g, in ReadOnlySpan<char> word, Point position, Font font, Color foreColor, Brush backBrush)
         {
-            if (string.IsNullOrEmpty(word))
+            if (word.IsEmpty)
                 return 0;
 
             if (word.Length > MaximumWordLength)
@@ -545,9 +547,9 @@ namespace ICSharpCode.TextEditor
                     var pos = position;
                     pos.X += width;
                     if (i + MaximumWordLength < word.Length)
-                        width += DrawDocumentWord(g, word.Substring(i, MaximumWordLength), pos, font, foreColor, backBrush);
+                        width += DrawDocumentWord(g, word[i..MaximumWordLength], pos, font, foreColor, backBrush);
                     else
-                        width += DrawDocumentWord(g, word.Substring(i, word.Length - i), pos, font, foreColor, backBrush);
+                        width += DrawDocumentWord(g, word[i..], pos, font, foreColor, backBrush);
                 }
 
                 return width;
@@ -570,40 +572,17 @@ namespace ICSharpCode.TextEditor
             return wordWidth;
         }
 
-        private struct WordFontPair
-        {
-            private readonly string word;
-            private readonly Font font;
-
-            public WordFontPair(string word, Font font)
-            {
-                this.word = word;
-                this.font = font;
-            }
-
-            public override bool Equals(object? obj)
-            {
-                return obj is WordFontPair other
-                    && word.Equals(other.word)
-                    && font.Equals(other.font);
-            }
-
-            public override int GetHashCode()
-            {
-                return word.GetHashCode() ^ font.GetHashCode();
-            }
-        }
-
-        private readonly Dictionary<WordFontPair, int> measureCache = new Dictionary<WordFontPair, int>();
+        private readonly Dictionary<string, Dictionary<Font, int>> measureCache = [];
+        private readonly Dictionary<string, Dictionary<Font, int>>.AlternateLookup<ReadOnlySpan<char>> _measureCacheSpanLookup;
 
         // split words after 1000 characters. Fixes GDI+ crash on very longs words, for example
         // a 100 KB Base64-file without any line breaks.
         private const int MaximumWordLength = 1000;
         private const int MaximumCacheSize = 2000;
 
-        private int MeasureStringWidth(Graphics g, string word, Font font)
+        private int MeasureStringWidth(Graphics g, in ReadOnlySpan<char> word, Font font)
         {
-            if (string.IsNullOrEmpty(word))
+            if (word.IsEmpty)
                 return 0;
             int width;
             if (word.Length > MaximumWordLength)
@@ -611,13 +590,13 @@ namespace ICSharpCode.TextEditor
                 width = 0;
                 for (var i = 0; i < word.Length; i += MaximumWordLength)
                     if (i + MaximumWordLength < word.Length)
-                        width += MeasureStringWidth(g, word.Substring(i, MaximumWordLength), font);
+                        width += MeasureStringWidth(g, word[i..MaximumWordLength], font);
                     else
-                        width += MeasureStringWidth(g, word.Substring(i, word.Length - i), font);
+                        width += MeasureStringWidth(g, word[i..], font);
                 return width;
             }
 
-            if (measureCache.TryGetValue(new WordFontPair(word, font), out width))
+            if (_measureCacheSpanLookup.TryGetValue(word, out Dictionary<Font, int>? fontWidths) && fontWidths.TryGetValue(font, out width))
                 return width;
             if (measureCache.Count > MaximumCacheSize)
                 measureCache.Clear();
@@ -630,7 +609,11 @@ namespace ICSharpCode.TextEditor
             // [...]
             // Replaced GDI+ measurement with GDI measurement: faster and even more exact
             width = TextRenderer.MeasureText(g, word, font, new Size(short.MaxValue, short.MaxValue), textFormatFlags).Width;
-            measureCache.Add(new WordFontPair(word, font), width);
+            if (!_measureCacheSpanLookup.TryGetValue(word, out fontWidths))
+                _measureCacheSpanLookup[word] = new Dictionary<Font, int>() { { font, width } };
+            else
+                fontWidths[font] = width;
+
             return width;
         }
 
@@ -647,24 +630,24 @@ namespace ICSharpCode.TextEditor
 
         public int GetWidth(char ch, Font font)
         {
-            if (!fontBoundCharWidth.ContainsKey(font))
-                fontBoundCharWidth.Add(font, new Dictionary<char, int>());
-            if (!fontBoundCharWidth[font].ContainsKey(ch))
+            if (!fontBoundCharWidth.TryGetValue(font, out Dictionary<char, int>? widths))
+                fontBoundCharWidth[font] = widths = new Dictionary<char, int>();
+            if (!widths.TryGetValue(ch, out int width))
                 using (var g = textArea.CreateGraphics())
                 {
                     return GetWidth(g, ch, font);
                 }
 
-            return fontBoundCharWidth[font][ch];
+            return width;
         }
 
         public int GetWidth(Graphics g, char ch, Font font)
         {
-            if (!fontBoundCharWidth.ContainsKey(font))
-                fontBoundCharWidth.Add(font, new Dictionary<char, int>());
-            if (!fontBoundCharWidth[font].ContainsKey(ch))
-                fontBoundCharWidth[font].Add(ch, MeasureStringWidth(g, ch.ToString(), font));
-            return fontBoundCharWidth[font][ch];
+            if (!fontBoundCharWidth.TryGetValue(font, out Dictionary<char, int>? widths))
+                fontBoundCharWidth[font] = widths = new Dictionary<char, int>();
+            if (!widths.TryGetValue(ch, out int width))
+                widths[ch] = width = MeasureStringWidth(g, [ch], font);
+            return width;
         }
 
         public int GetWidth(Graphics g, string text, Font font)
@@ -856,7 +839,7 @@ namespace ICSharpCode.TextEditor
                             {
                                 for (var j = 0; j < text.Length; j++)
                                 {
-                                    newDrawingPos = drawingPos + MeasureStringWidth(g, text[j].ToString(), font);
+                                    newDrawingPos = drawingPos + MeasureStringWidth(g, [text[j]], font);
                                     if (newDrawingPos >= targetVisualPosX)
                                     {
                                         if (IsNearerToAThanB(targetVisualPosX, drawingPos, newDrawingPos))
@@ -1054,7 +1037,7 @@ namespace ICSharpCode.TextEditor
             g.DrawRectangle(Pens.Blue, rect);
         }
 
-        private static void DrawString(Graphics g, string text, Font font, Color color, int x, int y)
+        private static void DrawString(Graphics g, in ReadOnlySpan<char> text, Font font, Color color, int x, int y)
         {
             TextRenderer.DrawText(g, text, font, new Point(x, y), color, textFormatFlags);
         }

--- a/Project/Src/Util/RtfWriter.cs
+++ b/Project/Src/Util/RtfWriter.cs
@@ -7,6 +7,7 @@
 
 using System.Collections.Generic;
 using System.Drawing;
+using System.Runtime.InteropServices;
 using System.Text;
 using ICSharpCode.TextEditor.Document;
 
@@ -35,7 +36,7 @@ namespace ICSharpCode.TextEditor.Util
             rtf.Append(value: '\n');
             rtf.Append(@"\viewkind4\uc1\pard");
             rtf.Append(fileContent);
-            rtf.Append("}");
+            rtf.Append('}');
             return rtf.ToString();
         }
 
@@ -43,14 +44,14 @@ namespace ICSharpCode.TextEditor.Util
         {
             rtf.Append(@"{\colortbl ;");
             rtf.Append(colorString);
-            rtf.Append("}");
+            rtf.Append('}');
         }
 
         private static void BuildFontTable(IDocument doc, StringBuilder rtf)
         {
             rtf.Append(@"{\fonttbl");
-            rtf.Append(@"{\f0\fmodern\fprq1\fcharset0 " + doc.TextEditorProperties.Font.Name + ";}");
-            rtf.Append("}");
+            rtf.Append(@"{\f0\fmodern\fprq1\fcharset0 ").Append(doc.TextEditorProperties.Font.Name).Append(";}");
+            rtf.Append('}');
         }
 
         private static string BuildFileContent(TextArea textArea)
@@ -62,7 +63,7 @@ namespace ICSharpCode.TextEditor.Util
             var oldBold = false;
             var escapeSequence = false;
 
-            foreach (var selection in textArea.SelectionManager.SelectionCollection)
+            foreach (ISelection selection in CollectionsMarshal.AsSpan(textArea.SelectionManager.SelectionCollection))
             {
                 var selectionOffset = textArea.Document.PositionToOffset(selection.StartPosition);
                 var selectionEndOffset = textArea.Document.PositionToOffset(selection.EndPosition);
@@ -73,7 +74,7 @@ namespace ICSharpCode.TextEditor.Util
                     if (line.Words == null)
                         continue;
 
-                    foreach (var word in line.Words)
+                    foreach (TextWord word in CollectionsMarshal.AsSpan(line.Words))
                         switch (word.Type)
                         {
                             case TextWordType.Space:
@@ -96,15 +97,19 @@ namespace ICSharpCode.TextEditor.Util
                                 {
                                     var colorstr = c.R + ", " + c.G + ", " + c.B;
 
-                                    if (!colors.ContainsKey(colorstr))
+                                    if (!colors.TryGetValue(colorstr, out int color))
                                     {
-                                        colors[colorstr] = ++colorNum;
-                                        colorString.Append(@"\red" + c.R + @"\green" + c.G + @"\blue" + c.B + ";");
+                                        color = ++colorNum;
+                                        colors[colorstr] = color;
+                                        colorString.Append(@"\red").Append(c.R)
+                                            .Append(@"\green").Append(c.G)
+                                            .Append(@"\blue").Append(c.B)
+                                            .Append(';');
                                     }
 
                                     if (c != curColor || firstLine)
                                     {
-                                        rtf.Append(@"\cf" + colors[colorstr]);
+                                        rtf.Append(@"\cf").Append(color);
                                         curColor = c;
                                         escapeSequence = true;
                                     }
@@ -131,7 +136,7 @@ namespace ICSharpCode.TextEditor.Util
 
                                     if (firstLine)
                                     {
-                                        rtf.Append(@"\f0\fs" + textArea.TextEditorProperties.Font.Size*2);
+                                        rtf.Append(@"\f0\fs").Append(textArea.TextEditorProperties.Font.Size * 2);
                                         firstLine = false;
                                     }
 
@@ -183,7 +188,7 @@ namespace ICSharpCode.TextEditor.Util
                         if (c < 256)
                             rtfOutput.Append(c);
                         else
-                            rtfOutput.Append("\\u" + unchecked((short)c) + "?");
+                            rtfOutput.Append("\\u").Append(unchecked((short)c)).Append('?');
                         break;
                 }
         }


### PR DESCRIPTION
Also sprinled some `CollectionsMarshal.AsSpan` in changed files & avoid usage of interfaces to avoid virtual dispatch.

I was wondering why the `measureCache` is not `static`, but I guess it is to do with support for different scale monitors?